### PR TITLE
some improvements on wms add-layer-to-map process

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -589,12 +589,12 @@
             gnSearchLocation.setMap();
             // open dialog for WMS
             switch (type.toLowerCase()) {
-              case 'wms':
-                gnViewerService.openWmsTab(url);
-                break;
-
               case 'wmts':
                 gnViewerService.openWmtsTab(url);
+                break;
+
+              default:
+                gnViewerService.openWmsTab(url);
                 break;
             }
           },
@@ -1198,6 +1198,8 @@
                   if (version) {
                     o.version = version;
                   }
+                  /* it seems this adds an empty layer containing an error
+                     however we defer the error to the caller to manage display it to the user
                   olL = $this.addWmsToMap(map, o);
 
                   if (!angular.isArray(olL.get('errors'))) {
@@ -1214,7 +1216,7 @@
                   olL.get('errors').push(errors);
 
                   gnWmsQueue.error(o);
-                  o.layer = olL;
+                  o.layer = olL;*/
                   defer.reject(o);
                 } else {
                   olL = $this.createOlWMSFromCap(map, capL, url);

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -80,7 +80,20 @@
                  $filter('gnLocalized')(link.title) || link.title;
               if (layerName) {
                 gnMap.addWmsFromScratch(gnSearchSettings.viewerMap,
-                   url, layerName, false, md);
+                   url, layerName, false, md).
+                    then(function(result){
+                       gnAlertService.addAlert({
+                          msg: "Layer "+layerName+" added.",
+                          type: 'success'
+                        }); 
+                    }, function(error){
+                        gnAlertService.addAlert({
+                          msg: error.msg,
+                          type: 'warning'
+                        });
+                        //now load the service so a user can select a layer
+                        gnMap.addOwsServiceToMap(url, 'WMS');
+                    });
               } else {
                 gnMap.addOwsServiceToMap(url, 'WMS');
               }

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -308,6 +308,7 @@
                       scope.addLayerUrl[openedTool.tab] = openedTool.url;
                       break;
                   }
+                  scope.addLayerTabs.services = true;
                 }
 
                 // handle processes tool

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
@@ -153,9 +153,9 @@
             gnMdView.openMdFromLayer(scope.layer);
           };
           function resetPopup() {
-            // Hack to remove popup on layer remove eg.
-            $('[gn-popover-dropdown] .btn').each(function(i, button) {
-              $(button).popover('hide');
+            // Stronger hack to remove popup on layer remove eg.
+            $('div.popover').each(function(i, mnu) {
+              $(mnu).remove();
             });
           };
           scope.removeLayer = function(layer, map) {


### PR DESCRIPTION
- it displays a warning to the user if the layer is not available in capabilities
- it opens the service tab on the addlayer panel
- it prevents to add an empty layer with an error
- it removes the layer-settings (after clicking remove)

