### PR TITLE
Handle metadata spatial extent transform to projection with smaller domain of validity

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
@@ -86,7 +86,7 @@ public class MapRenderer {
      * Check if a geometry is in the domain of validity of a projection and if not return the
      * intersection of the geometry with the coordinate system domain of validity.
      */
-    private static Geometry computeGeomInDomainOfValidity(Geometry geom, CoordinateReferenceSystem mapCRS) {
+    public static Geometry computeGeomInDomainOfValidity(Geometry geom, CoordinateReferenceSystem mapCRS) {
         final GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory(null);
         final Extent domainOfValidity = mapCRS.getDomainOfValidity();
         Geometry adjustedGeom = geom;

--- a/services/src/main/java/org/fao/geonet/api/regions/MetadataRegion.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/MetadataRegion.java
@@ -27,6 +27,7 @@ import com.vividsolutions.jts.geom.Geometry;
 
 import org.fao.geonet.kernel.region.Region;
 import org.fao.geonet.api.regions.metadata.MetadataRegionSearchRequest.Id;
+import org.fao.geonet.api.records.extent.MapRenderer;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
@@ -53,6 +54,7 @@ public class MetadataRegion extends Region {
         Integer desiredCode = CRS.lookupEpsgCode(projection, false);
         boolean differentCrsCode = sourceCode == null || desiredCode == null || desiredCode.intValue() != sourceCode.intValue();
         if (differentCrsCode && !CRS.equalsIgnoreMetadata(coordinateReferenceSystem, projection)) {
+            geometry = MapRenderer.computeGeomInDomainOfValidity(geometry, projection);
             MathTransform transform = CRS.findMathTransform(coordinateReferenceSystem, projection, true);
             return JTS.transform(geometry, transform);
         }


### PR DESCRIPTION
I think this might have been your fix for this problem with bounding boxes.

I think this was the last blocker to displaying bounding polygons in the default view from my point of view (not breaking existing functionality).    I was thinking we could add an index field to enable this e.g. hasPolygon to 19115-3/19139 and check for geoBox or hasPolygon in recordView.