### PR TITLE
Handle transform to projection with smaller domain of validity

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
@@ -86,7 +86,7 @@ public class MapRenderer {
      * Check if a geometry is in the domain of validity of a projection and if not return the
      * intersection of the geometry with the coordinate system domain of validity.
      */
-    private static Geometry computeGeomInDomainOfValidity(Geometry geom, CoordinateReferenceSystem mapCRS) {
+    public static Geometry computeGeomInDomainOfValidity(Geometry geom, CoordinateReferenceSystem mapCRS) {
         final GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory(null);
         final Extent domainOfValidity = mapCRS.getDomainOfValidity();
         Geometry adjustedGeom = geom;
@@ -108,9 +108,8 @@ public class MapRenderer {
                         if (env.contains(geom.getEnvelopeInternal())) {
                             return geom;
                         } else {
-                            adjustedGeom = geometryFactory.toGeometry(
-                                env.intersection(geom.getEnvelopeInternal())
-                            );
+                            Geometry extentPolygon = JTS.toGeometry(env);
+                            adjustedGeom = geom.intersection(extentPolygon);
                         }
                     }
                 }

--- a/services/src/main/java/org/fao/geonet/api/regions/MetadataRegion.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/MetadataRegion.java
@@ -27,6 +27,7 @@ import com.vividsolutions.jts.geom.Geometry;
 
 import org.fao.geonet.kernel.region.Region;
 import org.fao.geonet.api.regions.metadata.MetadataRegionSearchRequest.Id;
+import org.fao.geonet.api.records.extent.MapRenderer;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
@@ -53,6 +54,7 @@ public class MetadataRegion extends Region {
         Integer desiredCode = CRS.lookupEpsgCode(projection, false);
         boolean differentCrsCode = sourceCode == null || desiredCode == null || desiredCode.intValue() != sourceCode.intValue();
         if (differentCrsCode && !CRS.equalsIgnoreMetadata(coordinateReferenceSystem, projection)) {
+            geometry = MapRenderer.computeGeomInDomainOfValidity(geometry, projection);
             MathTransform transform = CRS.findMathTransform(coordinateReferenceSystem, projection, true);
             return JTS.transform(geometry, transform);
         }

--- a/services/src/test/java/org/fao/geonet/api/records/extent/MapRendererTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/extent/MapRendererTest.java
@@ -10,8 +10,8 @@ import static org.junit.Assert.*;
 
 public class MapRendererTest {
 
-    private final transient WKTWriter wktWriter = new WKTWriter();
-    private final transient WKTReader wktReader = new WKTReader();
+    private final WKTWriter wktWriter = new WKTWriter();
+    private final WKTReader wktReader = new WKTReader();
 
     @Test
     public void domainContainsBoundingBox() throws Exception {

--- a/services/src/test/java/org/fao/geonet/api/records/extent/MapRendererTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/extent/MapRendererTest.java
@@ -1,0 +1,51 @@
+package org.fao.geonet.api.records.extent;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+import org.fao.geonet.kernel.region.Region;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MapRendererTest {
+
+    private final transient WKTWriter wktWriter = new WKTWriter();
+    private final transient WKTReader wktReader = new WKTReader();
+
+    @Test
+    public void domainContainsBoundingBox() throws Exception {
+        String test = "POLYGON ((40 -63, 40 -20, 70 -20, 70 -63, 40 -63))";
+        Geometry bbox = wktReader.read(test);
+        bbox.setSRID(4326);
+        String result = wktWriter.write(MapRenderer.computeGeomInDomainOfValidity(bbox, Region.decodeCRS("EPSG:3857")));
+        assertEquals(test, result);
+    }
+
+    @Test
+    public void domainIntersectsBoundingBox() throws Exception {
+        String test = "POLYGON ((40 -86, 40 -20, 70 -20, 70 -86, 40 -86))";
+        Geometry bbox = wktReader.read(test);
+        bbox.setSRID(4326);
+        String result = wktWriter.write(MapRenderer.computeGeomInDomainOfValidity(bbox, Region.decodeCRS("EPSG:3857")));
+        assertEquals("POLYGON ((40 -85.06, 40 -20, 70 -20, 70 -85.06, 40 -85.06))", result);
+    }
+
+    @Test
+    public void domainContainsBoundingPolygon() throws Exception {
+        String test = "POLYGON ((165 -83, 135 -76, 161 -76, 153 -81, 165 -83))";
+        Geometry bbox = wktReader.read(test);
+        bbox.setSRID(4326);
+        String result = wktWriter.write(MapRenderer.computeGeomInDomainOfValidity(bbox, Region.decodeCRS("EPSG:3857")));
+        assertEquals("POLYGON ((165 -83, 135 -76, 161 -76, 153 -81, 165 -83))", result);
+    }
+
+    @Test
+    public void domainIntersectsBoundingPolygon() throws Exception {
+        String test = "POLYGON ((165 -87, 135 -76, 161 -76, 153 -81, 165 -87))";
+        Geometry bbox = wktReader.read(test);
+        bbox.setSRID(4326);
+        String result = wktWriter.write(MapRenderer.computeGeomInDomainOfValidity(bbox, Region.decodeCRS("EPSG:3857")));
+        assertEquals("POLYGON ((159.70909090909092 -85.06, 135 -76, 161 -76, 153 -81, 161.12 -85.06, 159.70909090909092 -85.06))", result);
+    }
+}


### PR DESCRIPTION
Fixes last remaining issue that I know of using api/record/extent to draw spatial extents instead of previous code which only handled bounding boxes.   Still an issue if bounding box or bounding polygon crosses the anti-meridian, but then we never do this - we split them at the anti-meridian.  This was also a problem in the old code for bounding boxes anyway. 

![image](https://user-images.githubusercontent.com/1860215/75869549-d3680300-5e5d-11ea-9df2-99d6932e2e66.png)

![image](https://user-images.githubusercontent.com/1860215/75869615-ef6ba480-5e5d-11ea-910f-5d5b0a73f93f.png)
